### PR TITLE
Update Bloodborne codes

### DIFF
--- a/PS4/CUSA00207.savepatch
+++ b/PS4/CUSA00207.savepatch
@@ -422,8 +422,12 @@
 ;The Isz Glitch is a bug in Bloodborne that prevents certain characters from creating all possible Isz dungeons.
 ;More info: https://github.com/jrson83/bloodborne-isz-glitch-cure
 
-[Isz Glitch Cure (Character must be affected by Isz Glitch)]
-80010004 07001300
-92000000 00000DB3
+[Isz Glitch Cure (Fixes Isz Glitch, character may or may not be affected by Isz Glitch)]
+80010008 03000000
+05000100 00000000
+92000000 00000DD1
+D8000000 020130FF
+D8000000 0103C0FF
+08000001 00000030
 D8000000 0100C0FF
-18000000 0000FFFF
+08000001 000000FF

--- a/PS4/CUSA00900.savepatch
+++ b/PS4/CUSA00900.savepatch
@@ -650,8 +650,12 @@
 ;The Isz Glitch is a bug in Bloodborne that prevents certain characters from creating all possible Isz dungeons.
 ;More info: https://github.com/jrson83/bloodborne-isz-glitch-cure
 
-[Isz Glitch Cure (Character must be affected by Isz Glitch)]
-80010004 07001300
-92000000 00000DB3
+[Isz Glitch Cure (Fixes Isz Glitch, character may or may not be affected by Isz Glitch)]
+80010008 03000000
+05000100 00000000
+92000000 00000DD1
+D8000000 020130FF
+D8000000 0103C0FF
+08000001 00000030
 D8000000 0100C0FF
-18000000 0000FFFF
+08000001 000000FF


### PR DESCRIPTION
The Isz Glitch Cure Quick Code has been updated to ensure that a character who has not yet looted all unique Isz items can still loot them after applying the patch.

The new Quick Code has been tested using Savewizard and Apollo Patcher successfully.

For coverage check this [gist](https://gist.github.com/jrson83/11263531d557603ad12b45b98d227502).