### PR TITLE
Add goat simulator 3 decrypter

### DIFF
--- a/PS4/CUSA46680.savepatch
+++ b/PS4/CUSA46680.savepatch
@@ -1,0 +1,22 @@
+; CUSA46680
+; Goat Simulator 3
+; decryption by Bucanero
+
+:ue4savegame.ps4.sav
+
+[python:Decrypt and Unpack Savedata (Required)]
+import goat_sim3
+
+goat_sim3.gs3_crypt(goat_sim3.DECRYPT, savedata)
+
+
+;
+;[example]
+;cheat codes should go here
+;
+
+
+[python:Encrypt and Pack Savedata (Required)]
+import goat_sim3
+
+goat_sim3.gs3_crypt(goat_sim3.ENCRYPT, savedata)

--- a/python/goat_sim3.py
+++ b/python/goat_sim3.py
@@ -1,0 +1,107 @@
+"""
+Goat Simulator 3 - PS4 Save Decrypt/Re-encrypt Tool
+
+Apollo script by Bucanero, based on python script by brotherguns5624
+
+HOW THE SAVE IS STRUCTURED
+---------------------------
+
+  Bytes 0-7   : Magic constant  0x1a4777924f98f282  (plaintext, little-endian)
+  Bytes 8-11  : Uncompressed size (little-endian uint32)
+  Bytes 12-15 : Ciphertext size  (little-endian uint32)
+  Bytes 16+   : AES-256-ECB encrypted payload
+
+The encrypted payload decrypts to a zlib-compressed UE4 GVAS binary.
+
+CIPHER DETAILS (from EBOOT.ELF reverse engineering)
+-----------------------------------------------------
+  Algorithm : AES-256-ECB  (no IV, no CBC chaining)
+  Key       : hardcoded 32 bytes at VA 0x06efa6d0 in EBOOT.ELF
+              (file offset 0x6efe6d0)
+  Padding   : PKCS7 to 16-byte boundary
+  After AES : zlib decompress -> raw GVAS
+
+The AES implementation is a custom 4-table lookup (not OpenSSL).
+Key schedule lives in FUN_02f3b890, encrypt in FUN_023af540,
+decrypt in FUN_02f3b9e0.
+"""
+
+import ucrypto
+import uzlib as zlib
+import ustruct as struct
+
+ENCRYPT = ucrypto.ENCRYPT
+DECRYPT = ucrypto.DECRYPT
+
+# Hardcoded AES-256 key from EBOOT.ELF (VA 0x06efa6d0)
+AES256_KEY = b'L\x08Tq:Q\xa1\x04\xfe\x9b\x1fu"u\xd26O`\x06D\xb6\xdeOTs\xdb[\x92\'>\xc0\xaf'
+
+# Save file magic (first 8 bytes, stored little-endian)
+MAGIC = 0x82f2984f9277471a  # = 0x1a4777924f98f282 as bytes in file
+
+
+def goats3_decrypt(data, cipher_size):
+    """
+    Decrypt a GS3 PS4 save file -> raw GVAS binary.
+    """
+    ciphertext  = data[16:16 + cipher_size]
+
+    # AES-256-ECB decrypt
+    plain = ucrypto.aes_ecb(DECRYPT, ciphertext, AES256_KEY)
+
+    # Strip PKCS7 padding (last byte tells you how many pad bytes to remove)
+    pad   = plain[-1]
+    plain = plain[:-pad]
+
+    # zlib decompress -> GVAS
+    out = zlib.decompress(plain)
+
+    print("Decrypted + unpacked {} bytes".format(len(out)))
+    return data[:16] + out
+
+
+def goats3_encrypt(data, decomp_size):
+    """
+    Re-encrypt a modified GVAS back into a GS3 PS4 save file.
+    """
+    plain = data[16:16 + decomp_size]
+
+    # zlib compress
+    compressed = zlib.compress(plain)
+
+    # PKCS7 pad to 16-byte boundary
+    pad        = 16 - (len(compressed) % 16)
+    compressed += bytes([pad]) * pad
+
+    cipher_size = len(compressed)
+
+    # AES-256-ECB encrypt
+    ciphertext = ucrypto.aes_ecb(ENCRYPT, compressed, AES256_KEY)
+
+    # Write header + ciphertext
+    header = struct.pack('<QII', MAGIC, decomp_size, cipher_size)
+
+    print("Encrypted + compressed {} bytes".format(cipher_size))
+    return header + ciphertext
+
+
+def gs3_crypt(mode, data: bytearray):
+    # Verify magic
+    magic, decomp_size, cipher_size = struct.unpack_from('<QII', data, 0)
+    if magic != MAGIC:
+        raise ValueError("Not a GS3 save - bad magic: {}".format(magic))
+
+    if mode == DECRYPT:
+        data[:] = goats3_decrypt(data, cipher_size)
+
+        if (len(data) - 16) != decomp_size:
+            raise ValueError("Decompress size mismatch, expected: {}".format(decomp_size))
+
+        print("Decryption complete, {} bytes".format(len(data)))
+
+    elif mode == ENCRYPT:
+        data[:] = goats3_encrypt(data, decomp_size)
+        print("Encryption complete, {} bytes".format(len(data)))
+
+    else:
+        raise Exception("Error: Unknown mode '{}', must be 'ENCRYPT' or 'DECRYPT'".format(mode))


### PR DESCRIPTION
reference:
```py
#!/usr/bin/env python3
"""
Goat Simulator 3 - PS4 Save Decrypt/Re-encrypt Tool
Game: CUSA46680

HOW THE SAVE IS STRUCTURED
---------------------------
The PS4 OS-level encryption is already stripped by the time you have the file
(Apollo / SaveWizard / FTP dump handles that layer).

What's left is a second application-level layer the game adds itself:

  Bytes 0-7   : Magic constant  0x1a4777924f98f282  (plaintext, little-endian)
  Bytes 8-11  : Uncompressed size (little-endian uint32)
  Bytes 12-15 : Ciphertext size  (little-endian uint32)
  Bytes 16+   : AES-256-ECB encrypted payload

The encrypted payload decrypts to a zlib-compressed UE4 GVAS binary.

CIPHER DETAILS (from EBOOT.ELF reverse engineering)
-----------------------------------------------------
  Algorithm : AES-256-ECB  (no IV, no CBC chaining)
  Key       : hardcoded 32 bytes at VA 0x06efa6d0 in EBOOT.ELF
              (file offset 0x6efe6d0)
  Padding   : PKCS7 to 16-byte boundary
  After AES : zlib decompress -> raw GVAS

The AES implementation is a custom 4-table lookup (not OpenSSL).
Key schedule lives in FUN_02f3b890, encrypt in FUN_023af540,
decrypt in FUN_02f3b9e0.

REQUIREMENTS
------------
  pip install pycryptodome
"""

import struct
import zlib
import sys
from Crypto.Cipher import AES

# Hardcoded AES-256 key from EBOOT.ELF (VA 0x06efa6d0)
KEY = bytes.fromhex(
    '4c0854713a51a104'
    'fe9b1f752275d236'
    '4f600644b6de4f54'
    '73db5b92273ec0af'
)

# Save file magic (first 8 bytes, stored little-endian)
MAGIC = 0x82f2984f9277471a  # = 0x1a4777924f98f282 as bytes in file


def decrypt(path_in, path_out):
    """
    Decrypt a GS3 PS4 save file -> raw GVAS binary.

    path_in  : ue4savegame.ps4.sav  (after PS4 OS layer is stripped)
    path_out : output .gvas file (standard UE4 save, edit with any UE4 save tool)
    """
    data = open(path_in, 'rb').read()

    # Verify magic
    magic = struct.unpack_from('<Q', data, 0)[0]
    if magic != MAGIC:
        raise ValueError(f"Not a GS3 save - bad magic: {magic:#018x}")

    decomp_size = struct.unpack_from('<I', data, 8)[0]   # expected size after zlib decompress
    cipher_size = struct.unpack_from('<I', data, 12)[0]  # AES ciphertext byte count
    ciphertext  = data[16:16 + cipher_size]

    # AES-256-ECB decrypt
    plain = AES.new(KEY, AES.MODE_ECB).decrypt(ciphertext)

    # Strip PKCS7 padding (last byte tells you how many pad bytes to remove)
    pad   = plain[-1]
    plain = plain[:-pad]

    # zlib decompress -> GVAS
    out = zlib.decompress(plain)
    assert len(out) == decomp_size, f"Decompress size mismatch: {len(out)} != {decomp_size}"

    open(path_out, 'wb').write(out)
    print(f"[+] Decrypted: {path_out}  ({len(out)} bytes)")


def encrypt(path_in, path_out):
    """
    Re-encrypt a modified GVAS back into a GS3 PS4 save file.

    path_in  : modified .gvas file
    path_out : ue4savegame.ps4.sav  (drop back into the save folder on PS4)
    """
    plain = open(path_in, 'rb').read()
    decomp_size = len(plain)

    # zlib compress
    compressed = zlib.compress(plain, level=6)

    # PKCS7 pad to 16-byte boundary
    pad        = 16 - (len(compressed) % 16)
    compressed += bytes([pad]) * pad

    cipher_size = len(compressed)

    # AES-256-ECB encrypt
    ciphertext = AES.new(KEY, AES.MODE_ECB).encrypt(compressed)

    # Write header + ciphertext
    header = struct.pack('<QII', MAGIC, decomp_size, cipher_size)
    open(path_out, 'wb').write(header + ciphertext)
    print(f"[+] Encrypted: {path_out}  ({len(header + ciphertext)} bytes)")


if __name__ == '__main__':
    if len(sys.argv) != 4 or sys.argv[1] not in ('decrypt', 'encrypt'):
        print(__doc__)
        print("Usage:")
        print("  python gs3_save_tool.py decrypt  ue4savegame.ps4.sav  out.gvas")
        print("  python gs3_save_tool.py encrypt  modified.gvas         ue4savegame.ps4.sav")
        sys.exit(1)

    cmd = sys.argv[1]
    if cmd == 'decrypt':
        decrypt(sys.argv[2], sys.argv[3])
    else:
        encrypt(sys.argv[2], sys.argv[3])
``` 